### PR TITLE
OS name/version ping fix, redundant pings removed

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -1,62 +1,5 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
-install_event:
-  date_installed:
-    type: datetime
-    lifetime: ping
-    send_in_pings:
-      - events
-    description: |
-      The date and time the extension was installed and launched for the first time
-    bugs:
-      - https://linktobugs.page
-    data_reviews:
-      - https://linktodatareviews.page
-    notification_emails:
-      - gsherman@mozilla.com
-    expires: never
-  browser_type:
-    type: string
-    lifetime: ping
-    send_in_pings:
-      - events
-    description: |
-      The type of the browser the extension is running on (chromium vs firefox)
-    bugs:
-      - https://linktobugs.page
-    data_reviews:
-      - https://linktodatareviews.page
-    notification_emails:
-      - gsherman@mozilla.com
-    expires: never
-  browser_version:
-    type: string
-    lifetime: ping
-    send_in_pings:
-      - events
-    description: |
-      The name of the browser the extension is running on
-    bugs:
-      - https://linktobugs.page
-    data_reviews:
-      - https://linktodatareviews.page
-    notification_emails:
-      - gsherman@mozilla.com
-    expires: never
-  browser_name:
-    type: string
-    lifetime: ping
-    send_in_pings:
-      - events
-    description: |
-      The name of the browser the extension is running on
-    bugs:
-      - https://linktobugs.page
-    data_reviews:
-      - https://linktodatareviews.page
-    notification_emails:
-      - gsherman@mozilla.com
-    expires: never
 startup_event:
   date_started:
     type: datetime
@@ -177,6 +120,34 @@ startup_event:
       - events
     description: |
       The name of the user's set external browser (Firefox only)
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  os_name:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The name of the user's OS
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  os_version:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The version of the user's OS
     bugs:
       - https://linktobugs.page
     data_reviews:

--- a/test/shared/backgroundScripts/telemetry.test.js
+++ b/test/shared/backgroundScripts/telemetry.test.js
@@ -10,7 +10,6 @@ describe("shared/backgroundScripts/telemetry.js", () => {
       browser.runtime.getManifest = jest.fn(() => ({ version: "1.0.0" }));
       setExtensionPlatform("firefox");
       await initTelemetryListeners();
-      expect(browser.runtime.onInstalled.addListener).toHaveBeenCalled();
       expect(browser.runtime.onStartup.addListener).toHaveBeenCalled();
       expect(browser.storage.sync.onChanged.addListener).toHaveBeenCalled();
     });


### PR DESCRIPTION
As it turns out, not every field in the `client_info` ping is modifiable. See [the config parameter of Glean.initialize()](https://mozilla.github.io/glean.js/functions/core_glean.default.initialize.html). Thus, the custom OS name and version were not being reported in the initialization. To report them properly, add these fields to the startup event.

The spec has also changed, with lots of fields shared between the install event and startup event being directed to just the startup event. So much so that, with the initialization of `client_info` and the startup pings, there is no more need for an install event. See the [install telemetry section of the spec](https://docs.google.com/document/d/1jTxG4kyDsgwAVHYkDvHvABmO85-wk9vppJe6ikNe76A/edit#heading=h.2fmwmhfme6rn), the extension version is reported as `appDisplayVersion` in the initialization of glean. The remaining fields are tbd.