### PR TITLE
Native Messaging to launch Firefox and check if Firefox is installed

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -191,7 +191,7 @@ launch_event:
       command:
         description: The command used within the NMH. LaunchFirefox/LaunchFirefoxPrivate
       native_messaging_host:
-        description: The NMH that was used to launch the browser
+        description: The id of the NMH used to launch the browser, which equates to the build channel and only to the build channel.
         type: string
       message:
         description: The error message

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -175,6 +175,27 @@ launch_event:
       source:
         description: Where the browser was launched from
         type: string
+  failed_browser_launch:
+    type: event
+    lifetime: ping
+    description: |
+      The browser did not launch due to a native messaging host fault. (Chromium Only)
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+    extra_keys:
+      command:
+        description: The command used within the NMH. LaunchFirefox/LaunchFirefoxPrivate
+      native_messaging_host:
+        description: The NMH that was used to launch the browser
+        type: string
+      message:
+        description: The error message
+        type: string
 setting_event:
   current_browser:
     type: event

--- a/src/chromium/interfaces/getters.js
+++ b/src/chromium/interfaces/getters.js
@@ -1,19 +1,29 @@
 import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
 
+const nativeApps = [
+  "org.mozilla.firefox_bridge_nmh_dev",
+  "org.mozilla.firefox_bridge_nmh_nightly",
+  "org.mozilla.firefox_bridge_nmh",
+  "org.mozilla.firefox_bridge_nmh_esr",
+];
+
 /**
- * Determines whether Firefox is installed on the system.
+ * Determines whether Firefox is installed on the system and returns the name of the installed Firefox variant in
+ * order of preference: dev, nightly, release, esr.
  *
- * @returns {Promise<boolean>} True if Firefox is installed on the system, false otherwise.
+ * @returns {Promise<string>} The name of the installed Firefox variant, or undefined if a Firefox variant is not installed.
  */
-export async function getIsFirefoxInstalled() {
-  // NOTE: We are not currently handling the case where Firefox is not installed until
-  // native messaging is implemented. We will assume for now that Firefox is always installed.
-  const result = await browser.storage.session.get("isFirefoxInstalled");
-  if (result.isFirefoxInstalled === undefined) {
-    browser.storage.session.set({ isFirefoxInstalled: true });
-    return true;
+export async function getInstalledFirefoxVariant() {
+  // Check for installed variants using the respective native messaging host.
+  for (const nativeApp of nativeApps) {
+    try {
+      await browser.runtime.sendNativeMessage(nativeApp, {
+        command: "GetVersion",
+      });
+      return nativeApp;
+    } catch (error) {}
   }
-  return result.isFirefoxInstalled;
+  return undefined;
 }
 
 /**

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -36,7 +36,7 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
       },
     );
 
-    if (response.result_code === 1) {
+    if (response.result_code !== 0) {
       throw new Error(response.message);
     }
     return true;

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -33,7 +33,7 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
       {
         command,
         data: { url },
-      }
+      },
     );
 
     if (response.result_code === 1) {
@@ -43,7 +43,7 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
   } catch (error) {
     console.error(
       `Error attempting to launch Firefox with ${nativeMessagingHost}:`,
-      error.message
+      error.message,
     );
   }
 

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -17,9 +17,9 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
 
   const nativeMessagingHost = await getInstalledFirefoxVariant();
   if (!nativeMessagingHost) {
-    // No Firefox variant is installed. Direct the user to the Firefox download page.
+    // No Firefox variant is installed. Direct the user to the welcome page.
     await browser.tabs.create({
-      url: "https://www.mozilla.org/firefox/new/",
+      url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
     });
     return false;
   }

--- a/src/chromium/interfaces/listeners.js
+++ b/src/chromium/interfaces/listeners.js
@@ -30,7 +30,7 @@ function registerEventRules() {
 export function initPlatformListeners() {
   browser.action.onClicked.addListener(async (tab) => {
     const browserName = await getExternalBrowser();
-    const success = launchBrowser(tab.url, browserName !== "Firefox");
+    const success = await launchBrowser(tab.url, browserName !== "Firefox");
     if (success) {
       launchEvent.browserLaunch.record({
         browser: await getExternalBrowser(),

--- a/src/chromium/manifest.json
+++ b/src/chromium/manifest.json
@@ -17,7 +17,8 @@
     "storage",
     "notifications",
     "declarativeNetRequest",
-    "declarativeContent"
+    "declarativeContent",
+    "nativeMessaging"
   ],
   "host_permissions": ["<all_urls>"],
   "background": {

--- a/src/firefox/interfaces/getters.js
+++ b/src/firefox/interfaces/getters.js
@@ -28,4 +28,4 @@ export async function getGreyedIconPath() {
   return { 32: browser.runtime.getURL(`images/${browserName}/32grey.png`) };
 }
 
-export function getIsFirefoxInstalled() {}
+export function getInstalledFirefoxVariant() {}

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -70,7 +70,8 @@ export function applyLocalization() {
   const hrefMapping = {
     welcomePageErrorChromium: "https://www.mozilla.org/firefox/new/",
     welcomePageTelemetryCheckbox: "https://example.com/", // TODO: replace with privacy policy link
-    welcomePageNoExternalBrowserErrorChromium: "https://www.mozilla.org/firefox/new/"
+    welcomePageNoExternalBrowserErrorChromium:
+      "https://www.mozilla.org/firefox/new/",
   };
 
   // attempt to replace each element

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -70,6 +70,7 @@ export function applyLocalization() {
   const hrefMapping = {
     welcomePageErrorChromium: "https://www.mozilla.org/firefox/new/",
     welcomePageTelemetryCheckbox: "https://example.com/", // TODO: replace with privacy policy link
+    welcomePageNoExternalBrowserErrorChromium: "https://www.mozilla.org/firefox/new/"
   };
 
   // attempt to replace each element

--- a/src/shared/pages/welcomePage/script.js
+++ b/src/shared/pages/welcomePage/script.js
@@ -6,7 +6,7 @@ import * as settingEvent from "../../generated/settingEvent.js";
 
 import { applyLocalization, replaceMessage } from "./localization.js";
 import { populateBrowserList } from "./browserList.js";
-import { getIsFirefoxInstalled } from "Interfaces/getters.js";
+import { getInstalledFirefoxVariant } from "Interfaces/getters.js";
 import { handleChangeDefaultLaunchContextMenuClick } from "Interfaces/contextMenus.js";
 
 import "Shared/backgroundScripts/polyfill.js";
@@ -191,7 +191,7 @@ export async function activatePlatformSpecificElements() {
     if (browser.runtime.getPlatformInfo().os === "android") {
       applyMobileLogic();
     }
-    if (!(await getIsFirefoxInstalled())) {
+    if (!(await getInstalledFirefoxVariant())) {
       document.getElementById("error-notification").style.display = "flex";
     }
   }

--- a/test/chromium/interfaces/getters.test.js
+++ b/test/chromium/interfaces/getters.test.js
@@ -8,7 +8,8 @@ import { setStorage } from "../../setup.test.js";
 
 describe("chromium/interfaces/getters.js", () => {
   describe("getInstalledFirefoxVariant()", () => {
-    it("should return true if a Firefox browser is installed", async () => {
+    it("should return something if a Firefox browser is installed", async () => {
+      // pass the validity test
       browser.runtime.sendNativeMessage.mockResolvedValue({
         version: "1.0",
       });
@@ -16,12 +17,46 @@ describe("chromium/interfaces/getters.js", () => {
       expect(result).toBeTruthy();
     });
 
-    it("should return false if a Firefox browser is not installed", async () => {
+    it("should return undefined if a Firefox browser is not installed", async () => {
+      // fail the validity test
       browser.runtime.sendNativeMessage.mockRejectedValue({
         message: "Receiving end does not exist.",
       });
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
+    });
+
+    it("should return the stored variant if storage correctly indicates a Firefox browser is installed", async () => {
+      await setStorage("nativeApp", "org.mozilla.firefox_bridge_nmh_sample");
+      // pass the validity test
+      browser.runtime.sendNativeMessage.mockResolvedValue({
+        version: "1.0",
+      });
+      const result = await getInstalledFirefoxVariant();
+      expect(result).toBe("org.mozilla.firefox_bridge_nmh_sample");
+    });
+
+    it("should return undefined if storage incorrectly indicates a Firefox variant is installed and no variant is installed", async () => {
+      await setStorage("nativeApp", "org.mozilla.firefox_bridge_nmh_sample");
+      // fail the validity test
+      browser.runtime.sendNativeMessage.mockRejectedValue({
+        message: "Receiving end does not exist.",
+      });
+      const result = await getInstalledFirefoxVariant();
+      expect(result).toBeFalsy();
+    });
+
+    it("should return a valid Firefox variant if the storage Firefox variant is invalid and there exists another valid variant", async () => {
+      await setStorage("nativeApp", "org.mozilla.invalid_variant");
+      // set isNativeAppValid to fail for the first variant and pass for the second
+      browser.runtime.sendNativeMessage.mockRejectedValueOnce({
+        message: "Receiving end does not exist.",
+      });
+      browser.runtime.sendNativeMessage.mockResolvedValueOnce({
+        version: "1.0",
+      });
+      const result = await getInstalledFirefoxVariant();
+      expect(result).toBe("org.mozilla.firefox_bridge_nmh_dev"); // this is the first variant in the list
     });
   });
 

--- a/test/chromium/interfaces/getters.test.js
+++ b/test/chromium/interfaces/getters.test.js
@@ -1,5 +1,5 @@
 import {
-  getIsFirefoxInstalled,
+  getInstalledFirefoxVariant,
   getDefaultIconPath,
   getGreyedIconPath,
 } from "../../../src/chromium/interfaces/getters.js";
@@ -7,16 +7,20 @@ import {
 import { setStorage } from "../../setup.test.js";
 
 describe("chromium/interfaces/getters.js", () => {
-  describe("getIsFirefoxInstalled()", () => {
+  describe("getInstalledFirefoxVariant()", () => {
     it("should return true if a Firefox browser is installed", async () => {
-      await setStorage("isFirefoxInstalled", true);
-      const result = await getIsFirefoxInstalled();
+      browser.runtime.sendNativeMessage.mockResolvedValue({
+        version: "1.0",
+      });
+      const result = await getInstalledFirefoxVariant();
       expect(result).toBeTruthy();
     });
 
     it("should return false if a Firefox browser is not installed", async () => {
-      await setStorage("isFirefoxInstalled", false);
-      const result = await getIsFirefoxInstalled();
+      browser.runtime.sendNativeMessage.mockRejectedValue({
+        message: "Receiving end does not exist.",
+      });
+      const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
     });
   });

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -11,9 +11,9 @@ describe("chromium/interfaces/launchBrowser.js", () => {
       const result = await launchBrowser("https://example.com", false);
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
-      expect(browser.tabs.create).toHaveBeenCalledWith({
-        url: "https://www.mozilla.org/firefox/new/",
-      });
+      expect(browser.runtime.getURL).toHaveBeenCalledWith(
+        "shared/pages/welcomePage/index.html",
+      );
     });
 
     it("should launch the current tab in Firefox", async () => {

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -32,7 +32,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         {
           command: "LaunchFirefox",
           data: { url: "https://mozilla.org" },
-        }
+        },
       );
     });
 
@@ -52,7 +52,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         {
           command: "LaunchFirefoxPrivate",
           data: { url: "https://mozilla.org" },
-        }
+        },
       );
     });
 
@@ -74,11 +74,11 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         {
           command: "LaunchFirefox",
           data: { url: "https://mozilla.org" },
-        }
+        },
       );
       expect(console.error).toHaveBeenCalledWith(
         "Error attempting to launch Firefox with org.mozilla.firefox_bridge_nmh_dev:",
-        ""
+        "",
       );
       console.error.mockRestore();
     });

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -4,42 +4,83 @@ import jest from "jest-mock";
 
 describe("chromium/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
-    it("should direct the user to the Firefox download page if Firefox is not installed", async () => {
-      await setStorage("isFirefoxInstalled", false);
+    it("should direct the user to the Firefox download page if a Firefox variant is not installed", async () => {
+      browser.runtime.sendNativeMessage.mockRejectedValue({
+        message: "Receiving end does not exist.",
+      });
       const result = await launchBrowser("https://example.com", false);
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
       expect(browser.tabs.create).toHaveBeenCalledWith({
-        url: "https://www.mozilla.org/firefox/",
+        url: "https://www.mozilla.org/firefox/new/",
       });
     });
 
     it("should launch the current tab in Firefox", async () => {
-      await setStorage("isFirefoxInstalled", true);
+      browser.runtime.sendNativeMessage.mockResolvedValue({
+        result_code: 0,
+      });
       setCurrentTab({
         id: 1,
         url: "https://mozilla.org",
       });
       const result = await launchBrowser("https://mozilla.org", false);
       expect(result).toBeTruthy();
-      expect(browser.tabs.update).toHaveBeenCalled();
-      expect(browser.tabs.update).toHaveBeenCalledWith(1, {
-        url: "firefox:https://mozilla.org",
-      });
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalled();
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalledWith(
+        "org.mozilla.firefox_bridge_nmh_dev",
+        {
+          command: "LaunchFirefox",
+          data: { url: "https://mozilla.org" },
+        }
+      );
     });
 
     it("should launch the current tab in Firefox Private Browsing", async () => {
-      await setStorage("isFirefoxInstalled", true);
+      browser.runtime.sendNativeMessage.mockResolvedValue({
+        result_code: 0,
+      });
       setCurrentTab({
         id: 1,
         url: "https://mozilla.org",
       });
       const result = await launchBrowser("https://mozilla.org", true);
       expect(result).toBeTruthy();
-      expect(browser.tabs.update).toHaveBeenCalled();
-      expect(browser.tabs.update).toHaveBeenCalledWith(1, {
-        url: "firefox-private:https://mozilla.org",
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalled();
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalledWith(
+        "org.mozilla.firefox_bridge_nmh_dev",
+        {
+          command: "LaunchFirefoxPrivate",
+          data: { url: "https://mozilla.org" },
+        }
+      );
+    });
+
+    it("should fail launching the current tab in an installed Firefox variant", async () => {
+      browser.runtime.sendNativeMessage.mockResolvedValue({
+        result_code: 1,
       });
+      // mock console.error
+      console.error = jest.fn();
+      setCurrentTab({
+        id: 1,
+        url: "https://mozilla.org",
+      });
+      const result = await launchBrowser("https://mozilla.org", false);
+      expect(result).toBeFalsy();
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalled();
+      expect(browser.runtime.sendNativeMessage).toHaveBeenCalledWith(
+        "org.mozilla.firefox_bridge_nmh_dev",
+        {
+          command: "LaunchFirefox",
+          data: { url: "https://mozilla.org" },
+        }
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        "Error attempting to launch Firefox with org.mozilla.firefox_bridge_nmh_dev:",
+        ""
+      );
+      console.error.mockRestore();
     });
 
     it("should not launch the current tab if the url scheme is not valid", async () => {

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -54,6 +54,7 @@ global.browser = {
       addListener: jest.fn(),
     },
     getManifest: jest.fn(),
+    sendNativeMessage: jest.fn(),
   },
   action: {
     setIcon: jest.fn(),


### PR DESCRIPTION
Fixes #79 
Fixes #54 
Fixes #50 

[Native Messaging document](https://docs.google.com/document/d/1I1WY5lV62zDy86CCceBXdQm-4PL18VKvXy8p6UmuA7g/edit)

This patch has 2 related changes. First, `isFirefoxInstalled()` is replaced by `getInstalledFirefoxVariant()` which uses native messaging to determine which firefox variant of Dev, Nightly, Release, ESR, is installed in that order with an early return if so. The return value is the native messaging host name to be used within `launchBrowser()`. This is where the extension commands the variant of firefox to open the url in normal or private mode. 