### PR TITLE
Link telemetry between extensions and Firefox

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -218,3 +218,17 @@ setting_event:
         description: The location that this setting was changed from
         type: string
     expires: never
+telemetry_event:
+  telemetry_id:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: The ID used to link the extensions and firefox together
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never

--- a/src/chromium/interfaces/getters.js
+++ b/src/chromium/interfaces/getters.js
@@ -25,7 +25,7 @@ export async function getInstalledFirefoxVariant() {
       }
       return true;
     } catch (error) {
-      console.error("Error getting NMH version:", error);
+      console.error("Error getting NMH version:", error.message);
       return false;
     }
   };
@@ -69,15 +69,9 @@ export async function getDefaultIconPath() {
  * Using native messaging, ets the telemetry ID for the Firefox profile to
  * link to the extension.
  *
- * @returns {string} The telemetry ID
+ * @returns {Promise<string>} The telemetry ID
  */
 export async function getTelemetryID() {
-  // Check if the telemetry ID is already stored in local storage.
-  const result = await browser.storage.local.get("telemetryID");
-  if (result.telemetryID !== undefined) {
-    return result.telemetryID;
-  }
-
   const nativeApp = await getInstalledFirefoxVariant();
   if (!nativeApp) {
     return undefined;
@@ -92,10 +86,9 @@ export async function getTelemetryID() {
     if (response.result_code !== 0) {
       throw new Error(response.message);
     }
-    await browser.storage.local.set({ telemetryID: response.message });
     return response.message;
   } catch (error) {
-    console.error("Error getting telemetry ID:", error);
+    console.error("Error getting telemetry ID:", error.message);
     return undefined;
   }
 }

--- a/src/chromium/interfaces/getters.js
+++ b/src/chromium/interfaces/getters.js
@@ -16,11 +16,16 @@ const nativeApps = [
 export async function getInstalledFirefoxVariant() {
   const isNativeAppValid = async (nativeApp) => {
     try {
-      await browser.runtime.sendNativeMessage(nativeApp, {
+      const response = await browser.runtime.sendNativeMessage(nativeApp, {
         command: "GetVersion",
+        data: {},
       });
+      if (response.result_code !== 0) {
+        throw new Error(response.message);
+      }
       return true;
     } catch (error) {
+      console.error("Error getting NMH version:", error);
       return false;
     }
   };
@@ -58,4 +63,39 @@ export async function getDefaultIconPath() {
   return {
     32: browser.runtime.getURL("images/firefox-private/private32.png"),
   };
+}
+
+/**
+ * Using native messaging, ets the telemetry ID for the Firefox profile to
+ * link to the extension.
+ *
+ * @returns {string} The telemetry ID
+ */
+export async function getTelemetryID() {
+  // Check if the telemetry ID is already stored in local storage.
+  const result = await browser.storage.local.get("telemetryID");
+  if (result.telemetryID !== undefined) {
+    return result.telemetryID;
+  }
+
+  const nativeApp = await getInstalledFirefoxVariant();
+  if (!nativeApp) {
+    return undefined;
+  }
+
+  // Get the telemetry ID from the native messaging host.
+  try {
+    const response = await browser.runtime.sendNativeMessage(nativeApp, {
+      command: "GetInstallId",
+      data: {},
+    });
+    if (response.result_code !== 0) {
+      throw new Error(response.message);
+    }
+    await browser.storage.local.set({ telemetryID: response.message });
+    return response.message;
+  } catch (error) {
+    console.error("Error getting telemetry ID:", error);
+    return undefined;
+  }
 }

--- a/src/chromium/interfaces/getters.js
+++ b/src/chromium/interfaces/getters.js
@@ -74,7 +74,7 @@ export async function getDefaultIconPath() {
 export async function getTelemetryID() {
   const nativeApp = await getInstalledFirefoxVariant();
   if (!nativeApp) {
-    return undefined;
+    return "";
   }
 
   // Get the telemetry ID from the native messaging host.
@@ -89,6 +89,6 @@ export async function getTelemetryID() {
     return response.message;
   } catch (error) {
     console.error("Error getting telemetry ID:", error.message);
-    return undefined;
+    return "";
   }
 }

--- a/src/firefox/api.js
+++ b/src/firefox/api.js
@@ -199,7 +199,7 @@ async function _launchBrowserMac(browserIdentifier, url) {
   if (!appExecutable) {
     throw new Error("Invalid browser identifier");
   }
-  console.log("appExecutable", appExecutable);
+
   let uri = Services.io.newURI(appExecutable);
   let file = uri.QueryInterface(Ci.nsIFileURL).file;
   let argsToUse = ["-a", file.path, url];
@@ -303,6 +303,19 @@ this.experiments_firefox_bridge = class extends ExtensionAPI {
           openShortcutsPage() {
             let win = Services.wm.getMostRecentWindow("navigator:browser");
             win.BrowserOpenAddonsMgr("addons://shortcuts/shortcuts");
+          },
+
+          /**
+           * Gets the telemetry ID for the Firefox profile to link to the extension.
+           *
+           * @returns {Promise<string>} The telemetry ID
+           */
+          async getTelemetryID() {
+            let telemetryID = Services.prefs.getStringPref(
+              "browser.firefoxbridge.installId",
+              undefined,
+            );
+            return telemetryID;
           },
         },
       },

--- a/src/firefox/api.js
+++ b/src/firefox/api.js
@@ -313,7 +313,7 @@ this.experiments_firefox_bridge = class extends ExtensionAPI {
           async getTelemetryID() {
             let telemetryID = Services.prefs.getStringPref(
               "browser.firefoxbridge.installId",
-              undefined,
+              "",
             );
             return telemetryID;
           },

--- a/src/firefox/interfaces/getters.js
+++ b/src/firefox/interfaces/getters.js
@@ -4,16 +4,8 @@ export function getInstalledFirefoxVariant() {}
 /**
  * Gets the telemetry ID for the Firefox profile to link to the extension.
  *
- * @returns {string} The telemetry ID
+ * @returns {Promise<string>} The telemetry ID
  */
-export async function getTelemetryID() {
-  // Check if the telemetry ID is already stored in local storage.
-  const result = browser.storage.local.get("telemetryID");
-  if (!result || result.telemetryID === undefined) {
-    const telemetryID =
-      await browser.experiments.firefox_bridge.getTelemetryID();
-    await browser.storage.local.set({ telemetryID });
-    return telemetryID;
-  }
-  return result.telemetryID;
+export function getTelemetryID() {
+  return browser.experiments.firefox_bridge.getTelemetryID();
 }

--- a/src/firefox/interfaces/getters.js
+++ b/src/firefox/interfaces/getters.js
@@ -1,2 +1,19 @@
 export async function getDefaultIconPath() {}
 export function getInstalledFirefoxVariant() {}
+
+/**
+ * Gets the telemetry ID for the Firefox profile to link to the extension.
+ *
+ * @returns {string} The telemetry ID
+ */
+export async function getTelemetryID() {
+  // Check if the telemetry ID is already stored in local storage.
+  const result = browser.storage.local.get("telemetryID");
+  if (!result || result.telemetryID === undefined) {
+    const telemetryID =
+      await browser.experiments.firefox_bridge.getTelemetryID();
+    await browser.storage.local.set({ telemetryID });
+    return telemetryID;
+  }
+  return result.telemetryID;
+}

--- a/src/firefox/schema.json
+++ b/src/firefox/schema.json
@@ -41,6 +41,13 @@
         "async": false,
         "description": "Opens the Firefox addons shortcuts page.",
         "parameters": []
+      },
+      {
+        "name": "getTelemetryID",
+        "type": "function",
+        "async": true,
+        "description": "Gets the telemetry ID from Firefox to link to the extension.",
+        "parameters": []
       }
     ]
   }

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -2,7 +2,6 @@
 import { initContextMenu, handleContextMenuClick } from "./contextMenus.js";
 import { handleHotkeyPress } from "./hotkeys.js";
 import { handleBrowserNameChange } from "./contextMenus.js";
-import { getTelemetryID } from "Interfaces/getters.js";
 // import { handleAutoRedirect, refreshDeclarativeNetRequestRules } from "./autoRedirect.js";
 
 /**
@@ -25,7 +24,6 @@ export function initSharedListeners() {
       browser.tabs.create({
         url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
       });
-      await browser.storage.local.set({ telemetryID: await getTelemetryID() });
     }
   });
 

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -2,6 +2,7 @@
 import { initContextMenu, handleContextMenuClick } from "./contextMenus.js";
 import { handleHotkeyPress } from "./hotkeys.js";
 import { handleBrowserNameChange } from "./contextMenus.js";
+import { getTelemetryID } from "Interfaces/getters.js";
 // import { handleAutoRedirect, refreshDeclarativeNetRequestRules } from "./autoRedirect.js";
 
 /**
@@ -24,6 +25,7 @@ export function initSharedListeners() {
       browser.tabs.create({
         url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
       });
+      await browser.storage.local.set({ telemetryID: await getTelemetryID() });
     }
   });
 

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -24,6 +24,10 @@ export async function initGlean(showLogs = false) {
     appDisplayVersion: browser.runtime.getManifest().version,
     appBuild: IS_FIREFOX_EXTENSION ? "firefox" : "chromium",
   });
+  const telemetryID = await getTelemetryID();
+  if (telemetryID) {
+    telemetryEvent.telemetryId.set(telemetryID);
+  }
 }
 
 /**
@@ -66,11 +70,14 @@ export function initTelemetryListeners() {
 
   browser.storage.sync.onChanged.addListener(async (changes) => {
     if (changes.telemetryEnabled !== undefined) {
-      await Glean.setUploadEnabled(changes.telemetryEnabled.newValue);
+      Glean.setUploadEnabled(changes.telemetryEnabled.newValue);
       if (changes.telemetryEnabled.newValue) {
         // Submit the telemetry ID each time telemetry is enabled as
         // the glean ID is reset each time telemetry is disabled.
-        telemetryEvent.telemetryId.set(await getTelemetryID());
+        const telemetryID = await getTelemetryID();
+        if (telemetryID) {
+          telemetryEvent.telemetryId.set(telemetryID);
+        }
       }
     }
   });

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -1,6 +1,8 @@
 import Glean from "@mozilla/glean/webext";
 import UAParser from "ua-parser-js";
 import * as startupEvent from "../generated/startupEvent.js";
+import * as telemetryEvent from "../generated/telemetryEvent.js";
+import { getTelemetryID } from "Interfaces/getters.js";
 
 import { getExternalBrowser, getTelemetryEnabled } from "./getters.js";
 
@@ -62,9 +64,14 @@ export function initTelemetryListeners() {
     }
   });
 
-  browser.storage.sync.onChanged.addListener((changes) => {
+  browser.storage.sync.onChanged.addListener(async (changes) => {
     if (changes.telemetryEnabled !== undefined) {
-      Glean.setUploadEnabled(changes.telemetryEnabled.newValue);
+      await Glean.setUploadEnabled(changes.telemetryEnabled.newValue);
+      if (changes.telemetryEnabled.newValue) {
+        // Submit the telemetry ID each time telemetry is enabled as
+        // the glean ID is reset each time telemetry is disabled.
+        telemetryEvent.telemetryId.set(await getTelemetryID());
+      }
     }
   });
 }

--- a/test/chromium/interfaces/getters.test.js
+++ b/test/chromium/interfaces/getters.test.js
@@ -4,13 +4,14 @@ import {
 } from "../../../src/chromium/interfaces/getters.js";
 
 import { setStorage } from "../../setup.test.js";
+import jest from "jest-mock";
 
 describe("chromium/interfaces/getters.js", () => {
   describe("getInstalledFirefoxVariant()", () => {
     it("should return something if a Firefox browser is installed", async () => {
       // pass the validity test
       browser.runtime.sendNativeMessage.mockResolvedValue({
-        version: "1.0",
+        result_code: 0,
       });
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeTruthy();
@@ -19,17 +20,19 @@ describe("chromium/interfaces/getters.js", () => {
     it("should return undefined if a Firefox browser is not installed", async () => {
       // fail the validity test
       browser.runtime.sendNativeMessage.mockRejectedValue({
-        message: "Receiving end does not exist.",
+        result_code: 1,
       });
+      console.error = jest.fn();
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
+      console.error.mockRestore();
     });
 
     it("should return the stored variant if storage correctly indicates a Firefox browser is installed", async () => {
       await setStorage("nativeApp", "org.mozilla.firefox_bridge_nmh_sample");
       // pass the validity test
       browser.runtime.sendNativeMessage.mockResolvedValue({
-        version: "1.0",
+        result_code: 0,
       });
       const result = await getInstalledFirefoxVariant();
       expect(result).toBe("org.mozilla.firefox_bridge_nmh_sample");
@@ -39,23 +42,27 @@ describe("chromium/interfaces/getters.js", () => {
       await setStorage("nativeApp", "org.mozilla.firefox_bridge_nmh_sample");
       // fail the validity test
       browser.runtime.sendNativeMessage.mockRejectedValue({
-        message: "Receiving end does not exist.",
+        result_code: 1,
       });
+      console.error = jest.fn();
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
+      console.error.mockRestore();
     });
 
     it("should return a valid Firefox variant if the storage Firefox variant is invalid and there exists another valid variant", async () => {
       await setStorage("nativeApp", "org.mozilla.invalid_variant");
       // set isNativeAppValid to fail for the first variant and pass for the second
       browser.runtime.sendNativeMessage.mockRejectedValueOnce({
-        message: "Receiving end does not exist.",
+        result_code: 1,
       });
       browser.runtime.sendNativeMessage.mockResolvedValueOnce({
-        version: "1.0",
+        result_code: 0,
       });
+      console.error = jest.fn();
       const result = await getInstalledFirefoxVariant();
       expect(result).toBe("org.mozilla.firefox_bridge_nmh_dev"); // this is the first variant in the list
+      console.error.mockRestore();
     });
   });
 

--- a/test/chromium/interfaces/getters.test.js
+++ b/test/chromium/interfaces/getters.test.js
@@ -5,7 +5,6 @@ import {
 } from "../../../src/chromium/interfaces/getters.js";
 
 import { setStorage } from "../../setup.test.js";
-import jest from "jest-mock";
 
 describe("chromium/interfaces/getters.js", () => {
   describe("getInstalledFirefoxVariant()", () => {
@@ -23,10 +22,8 @@ describe("chromium/interfaces/getters.js", () => {
       browser.runtime.sendNativeMessage.mockRejectedValue({
         result_code: 1,
       });
-      console.error = jest.fn();
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
-      console.error.mockRestore();
     });
 
     it("should return the stored variant if storage correctly indicates a Firefox browser is installed", async () => {
@@ -45,10 +42,9 @@ describe("chromium/interfaces/getters.js", () => {
       browser.runtime.sendNativeMessage.mockRejectedValue({
         result_code: 1,
       });
-      console.error = jest.fn();
+
       const result = await getInstalledFirefoxVariant();
       expect(result).toBeFalsy();
-      console.error.mockRestore();
     });
 
     it("should return a valid Firefox variant if the storage Firefox variant is invalid and there exists another valid variant", async () => {
@@ -60,10 +56,9 @@ describe("chromium/interfaces/getters.js", () => {
       browser.runtime.sendNativeMessage.mockResolvedValueOnce({
         result_code: 0,
       });
-      console.error = jest.fn();
+
       const result = await getInstalledFirefoxVariant();
       expect(result).toBe("org.mozilla.firefox_bridge_nmh_dev"); // this is the first variant in the list
-      console.error.mockRestore();
     });
   });
 
@@ -110,14 +105,13 @@ describe("chromium/interfaces/getters.js", () => {
         result_code: 1,
         message: "sample_error_message",
       });
-      console.error = jest.fn();
+
       const result = await getTelemetryID();
       expect(result).toBeFalsy();
       expect(console.error).toHaveBeenCalledWith(
         "Error getting telemetry ID:",
         "sample_error_message",
       );
-      console.error.mockRestore();
     });
 
     it("should return undefined if all validity tests fails", async () => {
@@ -126,7 +120,7 @@ describe("chromium/interfaces/getters.js", () => {
         result_code: 1,
         message: "sample_error_message",
       });
-      console.error = jest.fn();
+
       const result = await getTelemetryID();
       expect(result).toBeFalsy();
       // called 5 times, once for storage NMH, once for each NMH variant after
@@ -135,7 +129,6 @@ describe("chromium/interfaces/getters.js", () => {
         "Error getting NMH version:",
         "sample_error_message",
       );
-      console.error.mockRestore();
     });
   });
 });

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -6,8 +6,9 @@ describe("chromium/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should direct the user to the Firefox download page if a Firefox variant is not installed", async () => {
       browser.runtime.sendNativeMessage.mockRejectedValue({
-        message: "Receiving end does not exist.",
+        result_code: 1,
       });
+      console.error = jest.fn();
       const result = await launchBrowser("https://example.com", false);
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -57,7 +58,12 @@ describe("chromium/interfaces/launchBrowser.js", () => {
     });
 
     it("should fail launching the current tab in an installed Firefox variant", async () => {
-      browser.runtime.sendNativeMessage.mockResolvedValue({
+      // Pass the version check
+      browser.runtime.sendNativeMessage.mockResolvedValueOnce({
+        result_code: 0,
+      });
+      // Fail the launch
+      browser.runtime.sendNativeMessage.mockResolvedValueOnce({
         result_code: 1,
       });
       // mock console.error

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -1,6 +1,5 @@
 import { launchBrowser } from "../../../src/chromium/interfaces/launchBrowser.js";
 import { setCurrentTab, setStorage } from "../../setup.test.js";
-import jest from "jest-mock";
 
 describe("chromium/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
@@ -8,7 +7,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
       browser.runtime.sendNativeMessage.mockRejectedValue({
         result_code: 1,
       });
-      console.error = jest.fn();
+
       const result = await launchBrowser("https://example.com", false);
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -67,7 +66,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         result_code: 1,
       });
       // mock console.error
-      console.error = jest.fn();
+
       setCurrentTab({
         id: 1,
         url: "https://mozilla.org",
@@ -86,18 +85,16 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         "Error attempting to launch Firefox with org.mozilla.firefox_bridge_nmh_dev:",
         "",
       );
-      console.error.mockRestore();
     });
 
     it("should not launch the current tab if the url scheme is not valid", async () => {
       await setStorage("isFirefoxInstalled", true);
-      console.error = jest.fn();
+
       const result = await launchBrowser("invalid-url://mozilla.org", true);
       expect(result).toBeFalsy();
       expect(console.error).toHaveBeenCalled();
       expect(browser.tabs.create).not.toHaveBeenCalled();
       expect(browser.tabs.update).not.toHaveBeenCalled();
-      console.error.mockRestore();
     });
   });
 });

--- a/test/firefox/interfaces/getters.test.js
+++ b/test/firefox/interfaces/getters.test.js
@@ -1,0 +1,13 @@
+import { getTelemetryID } from "../../../src/firefox/interfaces/getters";
+
+describe("firefox/interfaces/getters.js", () => {
+  describe("getTelemetryID()", () => {
+    it("should return a telemetry ID", async () => {
+      browser.experiments.firefox_bridge.getTelemetryID.mockResolvedValue(
+        "sample_telemetry_id",
+      );
+      const result = await getTelemetryID();
+      expect(result).toBe("sample_telemetry_id");
+    });
+  });
+});

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -1,15 +1,12 @@
 import { launchBrowser } from "../../../src/firefox/interfaces/launchBrowser.js";
 import { setStorage } from "../../setup.test.js";
-import jest from "jest-mock";
 
 describe("firefox/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should return false if the url scheme is not valid", async () => {
-      console.error = jest.fn();
       const result = await launchBrowser("fake://example.com");
       expect(result).toEqual(false);
       expect(console.error).toHaveBeenCalled();
-      console.error.mockRestore();
     });
 
     it("should return false and open the welcome page if there is no set browser", async () => {
@@ -35,11 +32,9 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     });
 
     it("should return false if the browser is launched in private mode", async () => {
-      console.error = jest.fn();
       const result = await launchBrowser("https://example.com", true);
       expect(result).toEqual(false);
       expect(console.error).toHaveBeenCalled();
-      console.error.mockRestore();
     });
   });
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -225,9 +225,11 @@ await testInitializeGlean("firefox-bridge", false);
 beforeEach(async () => {
   await setStorage("isFirefoxInstalled", true, "session");
   setExtensionPlatform("firefox");
+  global.console.error = jest.fn();
 });
 
 afterEach(() => {
   resetStubs(global.browser);
   resetStubs(global.document);
+  global.console.error.mockRestore();
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -122,6 +122,7 @@ global.browser = {
       getAvailableBrowsers: jest.fn(),
       getDefaultBrowser: jest.fn(),
       launchBrowser: jest.fn(),
+      getTelemetryID: jest.fn(),
     },
   },
 };

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -1,5 +1,5 @@
 import "@babel/preset-env";
-import { testResetGlean } from "@mozilla/glean/testing";
+import { testInitializeGlean } from "@mozilla/glean/testing";
 import locales from "../src/_locales/en/messages.json";
 import jest from "jest-mock";
 
@@ -219,13 +219,14 @@ jest.spyOn(global.browser.i18n, "getMessage").mockImplementation((key) => {
   return getLocaleMessage(key);
 });
 
+await testInitializeGlean("firefox-bridge", false);
+
 beforeEach(async () => {
-  await testResetGlean("firefox-launch");
   await setStorage("isFirefoxInstalled", true, "session");
   setExtensionPlatform("firefox");
 });
 
-afterEach(() => {
+afterEach(async () => {
   resetStubs(global.browser);
   resetStubs(global.document);
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -227,7 +227,7 @@ beforeEach(async () => {
   setExtensionPlatform("firefox");
 });
 
-afterEach(async () => {
+afterEach(() => {
   resetStubs(global.browser);
   resetStubs(global.document);
 });


### PR DESCRIPTION
For the firefox extension:
- Accesses the preference `browser.firefoxbridge.installId` to get the generated ID from Firefox
- Submits this ID along with the glean ID whenever telemetry is turned on

For the chromium extension:
- Calls the native messaging host and requests the installId
- Submits this along with the glean ID whenever telemetry is turned on

The actual implementation for generating the ID in firefox is not yet complete.

[InstallID Spec](https://docs.google.com/document/d/1coIruhHHIADfb1fdD8PY_w3urZ7YIKp85lURNfGxoKE/edit#heading=h.5z4a4v590jeu)
[InstallID bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1887209)