### PR TITLE
Update CODEOWNERS to temporarily point to individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-src/_locales/en/*.json @mozilla-l10n/l10n-firefox-bridge
+src/_locales/en/*.json @bcolsson @flodolo


### PR DESCRIPTION
Revise CODEOWNERS to point to individual users until a team can be made within mozilla-extensions.