### PR TITLE
Welcome page string changes + glean link and email finalizing.

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -9,7 +9,7 @@ startup_event:
     description: |
       The date and time the extension was started up
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -23,7 +23,7 @@ startup_event:
     description: |
       The name of the browser the extension is running on
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -37,7 +37,7 @@ startup_event:
     description: |
       The user's preferred language of the browser
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -51,7 +51,7 @@ startup_event:
     description: |
       The language of the extension
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -65,7 +65,7 @@ startup_event:
     description: |
       Whether or not the action button is pinned to the toolbar
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -79,7 +79,7 @@ startup_event:
     description: |
       Which hotkeys are set for each command
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -93,7 +93,7 @@ startup_event:
     description: |
       The name of the user's browser
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -107,7 +107,7 @@ startup_event:
     description: |
       The version of the user's browser
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -121,7 +121,7 @@ startup_event:
     description: |
       The name of the user's set external browser (Firefox only)
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -135,7 +135,7 @@ startup_event:
     description: |
       The name of the user's OS
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -149,7 +149,7 @@ startup_event:
     description: |
       The version of the user's OS
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -162,7 +162,7 @@ launch_event:
     description: |
       The user launched the browser from the action button
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -181,7 +181,7 @@ launch_event:
     description: |
       The browser did not launch due to a native messaging host fault. (Chromium Only)
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -203,7 +203,7 @@ setting_event:
     lifetime: ping
     description: The external browser has been changed
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
@@ -227,7 +227,7 @@ telemetry_event:
       - events
     description: The ID used to link the extensions and firefox together
     bugs:
-      - https://github.com/mozilla-extensions/firefox-bridge/issues/
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     data_reviews:
       - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -9,11 +9,11 @@ startup_event:
     description: |
       The date and time the extension was started up
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   browser_type:
     type: string
@@ -23,11 +23,11 @@ startup_event:
     description: |
       The name of the browser the extension is running on
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   browser_language_locale:
     type: string
@@ -37,11 +37,11 @@ startup_event:
     description: |
       The user's preferred language of the browser
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   extension_language_locale:
     type: string
@@ -51,11 +51,11 @@ startup_event:
     description: |
       The language of the extension
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   is_pinned:
     type: boolean
@@ -65,11 +65,11 @@ startup_event:
     description: |
       Whether or not the action button is pinned to the toolbar
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   hotkeys:
     type: labeled_string
@@ -79,11 +79,11 @@ startup_event:
     description: |
       Which hotkeys are set for each command
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   browser_name:
     type: string
@@ -93,11 +93,11 @@ startup_event:
     description: |
       The name of the user's browser
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   browser_version:
     type: string
@@ -107,11 +107,11 @@ startup_event:
     description: |
       The version of the user's browser
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   external_browser:
     type: string
@@ -121,11 +121,11 @@ startup_event:
     description: |
       The name of the user's set external browser (Firefox only)
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   os_name:
     type: string
@@ -135,11 +135,11 @@ startup_event:
     description: |
       The name of the user's OS
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
   os_version:
     type: string
@@ -149,11 +149,11 @@ startup_event:
     description: |
       The version of the user's OS
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
 launch_event:
   browser_launch:
@@ -162,11 +162,11 @@ launch_event:
     description: |
       The user launched the browser from the action button
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
     extra_keys:
       browser:
@@ -181,15 +181,16 @@ launch_event:
     description: |
       The browser did not launch due to a native messaging host fault. (Chromium Only)
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never
     extra_keys:
       command:
         description: The command used within the NMH. LaunchFirefox/LaunchFirefoxPrivate
+        type: string
       native_messaging_host:
         description: The id of the NMH used to launch the browser, which equates to the build channel and only to the build channel.
         type: string
@@ -202,11 +203,11 @@ setting_event:
     lifetime: ping
     description: The external browser has been changed
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     extra_keys:
       from:
         description: The previously set browser
@@ -226,9 +227,9 @@ telemetry_event:
       - events
     description: The ID used to link the extensions and firefox together
     bugs:
-      - https://linktobugs.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/
     data_reviews:
-      - https://linktodatareviews.page
+      - https://github.com/mozilla-extensions/firefox-bridge/issues/87
     notification_emails:
-      - gsherman@mozilla.com
+      - dual-browser-owner@mozilla.com
     expires: never

--- a/pings.yaml
+++ b/pings.yaml
@@ -5,7 +5,7 @@ $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 #   include_client_id: true
 #   send_if_empty: false
 #   bugs:
-#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   data_reviews:
 #     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   notification_emails:
@@ -15,7 +15,7 @@ $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 #   include_client_id: true
 #   send_if_empty: false
 #   bugs:
-#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   data_reviews:
 #     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   notification_emails:
@@ -25,7 +25,7 @@ $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 #   include_client_id: true
 #   send_if_empty: false
 #   bugs:
-#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   data_reviews:
 #     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   notification_emails:
@@ -35,7 +35,7 @@ $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 #   include_client_id: true
 #   send_if_empty: false
 #   bugs:
-#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   data_reviews:
 #     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
 #   notification_emails:

--- a/pings.yaml
+++ b/pings.yaml
@@ -1,42 +1,42 @@
 $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 
-install:
-  description: Pings that are sent on install
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://example.com
-  data_reviews:
-    - https://example.com
-  notification_emails:
-    - gsherman@mozilla.com
-startup:
-  description: Pings that are sent on startup
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://example.com
-  data_reviews:
-    - https://example.com
-  notification_emails:
-    - gsherman@mozilla.com
-launch:
-  description: Pings that are sent when the browser is launched
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://example.com
-  data_reviews:
-    - https://example.com
-  notification_emails:
-    - gsherman@mozilla.com
-settings:
-  description: Pings that are sent when user settings change
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://example.com
-  data_reviews:
-    - https://example.com
-  notification_emails:
-    - gsherman@mozilla.com
+# install:
+#   description: Pings that are sent on install
+#   include_client_id: true
+#   send_if_empty: false
+#   bugs:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#   data_reviews:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
+#   notification_emails:
+#     - dual-browser-owner@mozilla.com
+# startup:
+#   description: Pings that are sent on startup
+#   include_client_id: true
+#   send_if_empty: false
+#   bugs:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#   data_reviews:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
+#   notification_emails:
+#     - dual-browser-owner@mozilla.com
+# launch:
+#   description: Pings that are sent when the browser is launched
+#   include_client_id: true
+#   send_if_empty: false
+#   bugs:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#   data_reviews:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
+#   notification_emails:
+#     - dual-browser-owner@mozilla.com
+# settings:
+#   description: Pings that are sent when user settings change
+#   include_client_id: true
+#   send_if_empty: false
+#   bugs:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/
+#   data_reviews:
+#     - https://github.com/mozilla-extensions/firefox-bridge/issues/87
+#   notification_emails:
+#     - dual-browser-owner@mozilla.com

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -137,10 +137,10 @@
   "welcomePageManageShortcutsChromium": {
     "message": "Find shortcuts for this extension by going to <a>extension settings.</a>"
   },
-  "welcomePageTryFirefox": {
+  "welcomePageTryOtherExtensionFirefox": {
     "message": "Want to hop back to Firefox from another browser? <a>Try our Chrome extension.</a>"
   },
-  "welcomePageTryChromium": {
+  "welcomePageTryOtherExtensionChromium": {
     "message": "Hop back to this browser with our <a>extension in Firefox.</a>"
   },
   "welcomePageDefaultBrowser": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -151,5 +151,14 @@
   },
   "welcomePageNoExternalBrowserErrorFirefox": {
     "message": "Looks like you don’t have another browser on this device"
+  },
+  "shortcutPageLaunchFirefoxDescription": {
+    "message": "Open Site in Firefox"
+  },
+  "shortcutPageLaunchFirefoxPrivateDescription": {
+    "message": "Open Site in Firefox Private Window"
+  },
+  "shortcutPageLaunchBrowserDescription": {
+    "message": "Open Site in your Selected Browser"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -138,10 +138,10 @@
     "message": "Find shortcuts for this extension by going to <a>extension settings.</a>"
   },
   "welcomePageTryFirefox": {
-    "message": "Want to hop back to Firefox? <a>Try our Chromium extension.</a>"
+    "message": "Want to hop back to Firefox from another browser? <a>Try our Chrome extension.</a>"
   },
   "welcomePageTryChromium": {
-    "message": "Hop back from another browser with our <a>extension in Firefox.</a>"
+    "message": "Hop back to this browser with our <a>extension in Firefox.</a>"
   },
   "welcomePageDefaultBrowser": {
     "message": "(Default Browser)"

--- a/src/chromium/manifest.json
+++ b/src/chromium/manifest.json
@@ -41,7 +41,7 @@
       "suggested_key": {
         "default": "Ctrl+Shift+P"
       },
-      "description": "__MSG_shortcutPageLaunchFirefoPrivateDescription__"
+      "description": "__MSG_shortcutPageLaunchFirefoxPrivateDescription__"
     }
   },
   "default_locale": "en"

--- a/src/chromium/manifest.json
+++ b/src/chromium/manifest.json
@@ -35,13 +35,13 @@
       "suggested_key": {
         "default": "Ctrl+Shift+F"
       },
-      "description": "Open Site in Firefox"
+      "description": "__MSG_shortcutPageLaunchFirefoxDescription__"
     },
     "launchFirefoxPrivate": {
       "suggested_key": {
         "default": "Ctrl+Shift+P"
       },
-      "description": "Open Site in Firefox Private Window"
+      "description": "__MSG_shortcutPageLaunchFirefoPrivateDescription__"
     }
   },
   "default_locale": "en"

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -27,7 +27,7 @@
       "suggested_key": {
         "default": "Ctrl+Shift+E"
       },
-      "description": "Open Site in your Selected Browser"
+      "description": "__MSG_shortcutPageLaunchBrowserDescription__"
     }
   },
   "default_locale": "en",

--- a/src/shared/pages/welcomePage/index.html
+++ b/src/shared/pages/welcomePage/index.html
@@ -62,7 +62,7 @@
           <p data-locale="welcomePageManageShortcuts"></p>
         </div>
 
-        <p data-locale="welcomePageTry"></p>
+        <p data-locale="welcomePageTryOtherExtension"></p>
       </div>
     </div>
   </body>

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -72,8 +72,8 @@ export function applyLocalization() {
     welcomePageTelemetryCheckbox: "https://example.com/", // TODO: replace with privacy policy link
     welcomePageNoExternalBrowserErrorChromium:
       "https://www.mozilla.org/firefox/new/",
-    welcomePageTryChromium: "https://mzl.la/dbe-firefox",
-    welcomePageTryFirefox: "https://mzl.la/dbe-chromium",
+    welcomePageTryOtherExtensionChromium: "https://mzl.la/dbe-firefox",
+    welcomePageTryOtherExtensionFirefox: "https://mzl.la/dbe-chromium",
   };
 
   // attempt to replace each element


### PR DESCRIPTION
Fixes #93 

This patch changes some welcome page strings, localizes shortcut strings, and updates the glean contact info in metrics.yaml. pings.yaml is required by the gleanjs builder but is not used since all pings are being sent in event pings, so it is commented out.