### PR TITLE
Add feedback action menu item, split the dynamic chrome action item into two constant ones.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -21,6 +21,9 @@
     "message": "Welcome to Firefox Bridge",
     "description": "'Firefox Bridge' is the name of the extension. Do not translate 'Firefox Bridge'."
   },
+  "leaveFeedbackContextMenu": {
+    "message": "Leave Feedback"
+  },
   "manageExternalSitesContextMenus": {
     "message": "Manage My External Sites"
   },

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -34,15 +34,6 @@ export async function applyPlatformContextMenus() {
 
   await browser.contextMenus.create(
     {
-      id: "separatorForLaunchModes",
-      type: "separator",
-      contexts: ["action"],
-    },
-    handleDuplicateIDError,
-  );
-
-  await browser.contextMenus.create(
-    {
       id: "changeDefaultLaunchContextMenu",
       title: browser.i18n.getMessage("changeDefaultLaunchContextMenu"),
       contexts: ["action"],
@@ -55,7 +46,7 @@ export async function applyPlatformContextMenus() {
   // separator
   await browser.contextMenus.create(
     {
-      id: "separator2",
+      id: "separator",
       type: "separator",
       contexts: ["action"],
     },

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -9,10 +9,38 @@ import { handleDuplicateIDError } from "Shared/backgroundScripts/contextMenus.js
  */
 export async function applyPlatformContextMenus() {
   const externalBrowserName = (await getExternalBrowser()) || "Firefox";
-  const alternateBrowserName =
-    externalBrowserName === "Firefox" ? "Firefox Private Browsing" : "Firefox";
 
   // action context menu
+  await browser.contextMenus.create(
+    {
+      id: "launchInFirefoxContextMenu",
+      title: browser.i18n.getMessage("launchInExternalBrowser", "Firefox"),
+      contexts: ["action"],
+    },
+    handleDuplicateIDError,
+  );
+
+  await browser.contextMenus.create(
+    {
+      id: "launchInFirefoxPrivateContextMenu",
+      title: browser.i18n.getMessage(
+        "launchInExternalBrowser",
+        "Firefox Private Browsing",
+      ),
+      contexts: ["action"],
+    },
+    handleDuplicateIDError,
+  );
+
+  await browser.contextMenus.create(
+    {
+      id: "separatorForLaunchModes",
+      type: "separator",
+      contexts: ["action"],
+    },
+    handleDuplicateIDError,
+  );
+
   await browser.contextMenus.create(
     {
       id: "changeDefaultLaunchContextMenu",
@@ -20,17 +48,6 @@ export async function applyPlatformContextMenus() {
       contexts: ["action"],
       type: "checkbox",
       checked: !(externalBrowserName === "Firefox"),
-    },
-    handleDuplicateIDError,
-  );
-  await browser.contextMenus.create(
-    {
-      id: "alternativeLaunchContextMenu",
-      title: browser.i18n.getMessage(
-        "launchInExternalBrowser",
-        alternateBrowserName,
-      ),
-      contexts: ["action"],
     },
     handleDuplicateIDError,
   );
@@ -109,12 +126,6 @@ export async function handleChangeDefaultLaunchContextMenuClick() {
   browser.contextMenus.update("changeDefaultLaunchContextMenu", {
     checked: externalBrowserName === "Firefox",
   });
-  browser.contextMenus.update("alternativeLaunchContextMenu", {
-    title: browser.i18n.getMessage(
-      "launchInExternalBrowser",
-      externalBrowserName,
-    ),
-  });
 
   if (externalBrowserName === "Firefox") {
     browser.storage.sync.set({
@@ -144,15 +155,17 @@ export async function handlePlatformContextMenuClick(info, tab) {
           : "Firefox",
       source: "action_context_menu",
     });
-  } else if (info.menuItemId === "alternativeLaunchContextMenu") {
-    // launch in the opposite mode to the default
-    if (await launchBrowser(tab.url, externalBrowserName === "Firefox")) {
-      const launchedBrowserName =
-        (await getExternalBrowser()) === "Firefox"
-          ? "Firefox Private Browsing"
-          : "Firefox";
+  } else if (info.menuItemId === "launchInFirefoxContextMenu") {
+    if (await launchBrowser(tab.url)) {
       launchEvent.browserLaunch.record({
-        browser: launchedBrowserName,
+        browser: "Firefox",
+        source: "action_context_menu",
+      });
+    }
+  } else if (info.menuItemId === "launchInFirefoxPrivateContextMenu") {
+    if (await launchBrowser(tab.url, true)) {
+      launchEvent.browserLaunch.record({
+        browser: "Firefox Private Browsing",
         source: "action_context_menu",
       });
     }

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -59,7 +59,7 @@ export async function initContextMenu() {
 
   const action = browser.browserAction ? "browser_action" : "action"; // mv2 vs mv3
 
-  //separator
+  // separator
   await browser.contextMenus.create(
     {
       id: "separator",
@@ -77,6 +77,16 @@ export async function initContextMenu() {
     {
       id: "openWelcomePage",
       title: browser.i18n.getMessage("openWelcomePage"),
+      contexts: [action],
+    },
+    handleDuplicateIDError,
+  );
+
+  // action menu leave feedback
+  await browser.contextMenus.create(
+    {
+      id: "leaveFeedback",
+      title: browser.i18n.getMessage("leaveFeedbackContextMenu"),
       contexts: [action],
     },
     handleDuplicateIDError,
@@ -130,6 +140,10 @@ export async function handleContextMenuClick(info, tab) {
   } else if (info.menuItemId === "openWelcomePage") {
     browser.tabs.create({
       url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
+    });
+  } else if (info.menuItemId === "leaveFeedback") {
+    browser.tabs.create({
+      url: "https://mzl.la/dbe-feedback",
     });
   } else {
     await handlePlatformContextMenuClick(info, tab);

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -59,16 +59,6 @@ export async function initContextMenu() {
 
   const action = browser.browserAction ? "browser_action" : "action"; // mv2 vs mv3
 
-  // separator
-  await browser.contextMenus.create(
-    {
-      id: "separator",
-      type: "separator",
-      contexts: [action],
-    },
-    handleDuplicateIDError,
-  );
-
   // platform specific menu
   await applyPlatformContextMenus();
 

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -13,7 +13,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
   describe("applyPlatformContextMenus()", () => {
     it("should create the chrome context menu", async () => {
       await applyPlatformContextMenus();
-      expect(browser.contextMenus.create).toHaveBeenCalledTimes(5);
+      expect(browser.contextMenus.create).toHaveBeenCalledTimes(7);
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
           id: "changeDefaultLaunchContextMenu",
@@ -26,7 +26,15 @@ describe("chromium/interfaces/contextMenus.js", () => {
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
-          id: "alternativeLaunchContextMenu",
+          id: "launchInFirefoxContextMenu",
+          title: getLocaleMessage("launchInExternalBrowser"),
+          contexts: ["action"],
+        },
+        handleDuplicateIDError,
+      );
+      expect(browser.contextMenus.create).toHaveBeenCalledWith(
+        {
+          id: "launchInFirefoxPrivateContextMenu",
           title: getLocaleMessage("launchInExternalBrowser"),
           contexts: ["action"],
         },
@@ -57,13 +65,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
       await handleChangeDefaultLaunchContextMenuClick({
         checked: true,
       });
-      expect(browser.contextMenus.update).toHaveBeenCalledTimes(2);
-      expect(browser.contextMenus.update).toHaveBeenCalledWith(
-        "alternativeLaunchContextMenu",
-        {
-          title: getLocaleMessage("launchInExternalBrowser"),
-        },
-      );
+      expect(browser.contextMenus.update).toHaveBeenCalledTimes(1);
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox Private Browsing",
       });
@@ -74,13 +76,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
       await handleChangeDefaultLaunchContextMenuClick({
         checked: false,
       });
-      expect(browser.contextMenus.update).toHaveBeenCalledTimes(2);
-      expect(browser.contextMenus.update).toHaveBeenCalledWith(
-        "alternativeLaunchContextMenu",
-        {
-          title: getLocaleMessage("launchInExternalBrowser"),
-        },
-      );
+      expect(browser.contextMenus.update).toHaveBeenCalledTimes(1);
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox",
       });

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -13,7 +13,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
   describe("applyPlatformContextMenus()", () => {
     it("should create the chrome context menu", async () => {
       await applyPlatformContextMenus();
-      expect(browser.contextMenus.create).toHaveBeenCalledTimes(7);
+      expect(browser.contextMenus.create).toHaveBeenCalledTimes(6);
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
           id: "changeDefaultLaunchContextMenu",
@@ -51,7 +51,16 @@ describe("chromium/interfaces/contextMenus.js", () => {
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
-          id: "separator2",
+          id: "launchInExternalBrowserPrivateLink",
+          title: getLocaleMessage("launchInExternalBrowserLink"),
+          contexts: ["link"],
+          targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
+        },
+        handleDuplicateIDError,
+      );
+      expect(browser.contextMenus.create).toHaveBeenCalledWith(
+        {
+          id: "separator",
           type: "separator",
           contexts: ["action"],
         },

--- a/test/shared/backgroundScripts/contextMenus.test.js
+++ b/test/shared/backgroundScripts/contextMenus.test.js
@@ -41,6 +41,14 @@ describe("shared/backgroundScripts/contextMenus.js", () => {
         },
         handleDuplicateIDError,
       );
+      expect(browser.contextMenus.create).toHaveBeenCalledWith(
+        {
+          id: "leaveFeedback",
+          title: getLocaleMessage("leaveFeedbackContextMenu"),
+          contexts: ["browser_action"],
+        },
+        handleDuplicateIDError,
+      );
     });
   });
 });


### PR DESCRIPTION
<img width="319" alt="Screenshot 2024-04-22 at 4 33 28 PM" src="https://github.com/mozilla-extensions/firefox-bridge/assets/63402349/9b6d427c-a896-4d5d-be4c-3771090ca093">
<img width="200" alt="Screenshot 2024-04-22 at 4 33 36 PM" src="https://github.com/mozilla-extensions/firefox-bridge/assets/63402349/920853e1-9f93-4093-b5a3-b5dbc4f5f057">

This is the final result in both extensions.

To do this within the chrome extension, some re-ordering had to occur to make room for the 6 item limit within the context menu. The separator counts as 1 item.