### PR TITLE
Remove unused permissions in manifest files

### DIFF
--- a/src/chromium/manifest.json
+++ b/src/chromium/manifest.json
@@ -15,12 +15,9 @@
     "contextMenus",
     "tabs",
     "storage",
-    "notifications",
-    "declarativeNetRequest",
     "declarativeContent",
     "nativeMessaging"
   ],
-  "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.bundle.js",
     "type": "module"

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -7,8 +7,6 @@
     "contextMenus",
     "tabs",
     "storage",
-    "notifications",
-    "declarativeNetRequest",
     "webNavigation",
     "mozillaAddons"
   ],


### PR DESCRIPTION
This is Greg Sherman's change to removed unused permissions, which Chrome Web Store does not allow. 