### PR TITLE
Added privacy policy to extension welcome page

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -89,17 +89,17 @@
   "welcomePageAlwaysPrivateCheckbox": {
     "message": "Always open sites in a Firefox Private Window when switching"
   },
-  "welcomePageTelemetryCheckbox": {
+  "welcomePageTelemetryCheckboxNotice": {
     "message": "Allow Mozilla to collect information about how you use this extension so we can make it better."
   },
   "welcomePagePrivacyPolicyIntro": {
-    "message": "The Firefox Bridge Extension allows you to open a web page in the browser of your choice. The <a>Mozilla Privacy Policy</a> describes how we handle information that we receive from you."
+    "message": "The Firefox Bridge extension allows you to open a web page in the browser of your choice. The <a>Mozilla Privacy Policy</a> describes how we handle information that we receive from you."
   },
   "welcomePagePrivacyPolicyDescription": {
     "message": "Here are the key things you should know about how the Firefox Bridge Extension handles your data:"
   },
   "welcomePagePrivacyPolicyInteractionData": {
-    "message": "Interaction data. Mozilla receives information about your interaction with Firefox Bridge across all instances of Firefox Bridge on your device, including (1) Event Data and Metrics data, such as when and how many pages you open in a new browser (though not what those pages are), (2) Interactions with Firefox Bridge’s menus and icons, and (3) Length of time you use the extension.  We also receive your device, operating system, version, and language preference, etc."
+    "message": "Interaction data. Mozilla receives information about your interaction with Firefox Bridge across all instances of Firefox Bridge on your device, including (1) Event Data and Metrics data, such as when and how many pages you open in a new browser (though not what those pages are), (2) Interactions with Firefox Bridge’s menus and icons, and (3) Length of time you use the extension.  We also receive your device operating system, version, and language preference, etc."
   },
   "welcomePageNoShortcutsFirefox": {
     "message": "You don’t have any shortcuts set up for this extension. Create them by going to <a>extension settings.</a>"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -96,10 +96,10 @@
     "message": "The Firefox Bridge extension allows you to open a web page in the browser of your choice. The <a>Mozilla Privacy Policy</a> describes how we handle information that we receive from you."
   },
   "welcomePagePrivacyPolicyDescription": {
-    "message": "Here are the key things you should know about how the Firefox Bridge Extension handles your data:"
+    "message": "Here are the key things you should know about how the Firefox Bridge extension handles your data:"
   },
   "welcomePagePrivacyPolicyInteractionData": {
-    "message": "Interaction data. Mozilla receives information about your interaction with Firefox Bridge across all instances of Firefox Bridge on your device, including (1) Event Data and Metrics data, such as when and how many pages you open in a new browser (though not what those pages are), (2) Interactions with Firefox Bridge’s menus and icons, and (3) Length of time you use the extension.  We also receive your device operating system, version, and language preference, etc."
+    "message": "Interaction data. Mozilla receives information about your interaction with Firefox Bridge across all instances of Firefox Bridge on your device, including (1) Event Data and Metrics data, such as when and how many pages you open in a new browser (though not what those pages are), (2) Interactions with Firefox Bridge’s menus and icons, and (3) Length of time you use the extension. We also receive your device operating system, version, and language preference, etc."
   },
   "welcomePageNoShortcutsFirefox": {
     "message": "You don’t have any shortcuts set up for this extension. Create them by going to <a>extension settings.</a>"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -90,7 +90,16 @@
     "message": "Always open sites in a Firefox Private Window when switching"
   },
   "welcomePageTelemetryCheckbox": {
-    "message": "Allow Mozilla to collect information about how you use this extension so we can make it better. <a>Privacy Notice</a>"
+    "message": "Allow Mozilla to collect information about how you use this extension so we can make it better."
+  },
+  "welcomePagePrivacyPolicyIntro": {
+    "message": "The Firefox Bridge Extension allows you to open a web page in the browser of your choice. The <a>Mozilla Privacy Policy</a> describes how we handle information that we receive from you."
+  },
+  "welcomePagePrivacyPolicyDescription": {
+    "message": "Here are the key things you should know about how the Firefox Bridge Extension handles your data:"
+  },
+  "welcomePagePrivacyPolicyInteractionData": {
+    "message": "Interaction data. Mozilla receives information about your interaction with Firefox Bridge across all instances of Firefox Bridge on your device, including (1) Event Data and Metrics data, such as when and how many pages you open in a new browser (though not what those pages are), (2) Interactions with Firefox Bridge’s menus and icons, and (3) Length of time you use the extension.  We also receive your device, operating system, version, and language preference, etc."
   },
   "welcomePageNoShortcutsFirefox": {
     "message": "You don’t have any shortcuts set up for this extension. Create them by going to <a>extension settings.</a>"

--- a/src/shared/pages/welcomePage/index.html
+++ b/src/shared/pages/welcomePage/index.html
@@ -59,7 +59,7 @@
             <input type="checkbox" id="telemetry-checkbox" class="slider" />
           </div>
           <label
-            data-locale="welcomePageTelemetryCheckbox"
+            data-locale="welcomePageTelemetryCheckboxNotice"
             for="telemetry-checkbox"
           ></label>
         </div>

--- a/src/shared/pages/welcomePage/index.html
+++ b/src/shared/pages/welcomePage/index.html
@@ -46,6 +46,14 @@
           ></label>
         </div>
 
+        <div class="shortcuts" id="shortcuts-container">
+          <h3 data-locale="welcomePageShortcutTitle">Shortcuts</h3>
+          <div id="shortcuts-list"></div>
+          <p data-locale="welcomePageManageShortcuts"></p>
+        </div>
+
+        <p data-locale="welcomePageTryOtherExtension"></p>
+
         <div class="telemetry">
           <div class="checkbox-container">
             <input type="checkbox" id="telemetry-checkbox" class="slider" />
@@ -56,13 +64,9 @@
           ></label>
         </div>
 
-        <div class="shortcuts" id="shortcuts-container">
-          <h3 data-locale="welcomePageShortcutTitle">Shortcuts</h3>
-          <div id="shortcuts-list"></div>
-          <p data-locale="welcomePageManageShortcuts"></p>
-        </div>
-
-        <p data-locale="welcomePageTryOtherExtension"></p>
+        <p data-locale="welcomePagePrivacyPolicyIntro"></p>
+        <p data-locale="welcomePagePrivacyPolicyDescription"></p>
+        <p data-locale="welcomePagePrivacyPolicyInteractionData"></p>
       </div>
     </div>
   </body>

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -69,7 +69,7 @@ export function applyLocalization() {
   const elements = document.querySelectorAll("[data-locale]");
   const hrefMapping = {
     welcomePageErrorChromium: "https://mzl.la/dbe-fxinstall",
-    welcomePagePrivacyPolicyIntro: "https://www.mozilla.org/en-US/privacy/",
+    welcomePagePrivacyPolicyIntro: "https://www.mozilla.org/privacy/",
     welcomePageNoExternalBrowserErrorChromium:
       "https://www.mozilla.org/firefox/new/",
     welcomePageTryOtherExtensionChromium: "https://mzl.la/dbe-firefox",

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -69,7 +69,7 @@ export function applyLocalization() {
   const elements = document.querySelectorAll("[data-locale]");
   const hrefMapping = {
     welcomePageErrorChromium: "https://mzl.la/dbe-fxinstall",
-    welcomePageTelemetryCheckbox: "https://example.com/", // TODO: replace with privacy policy link
+    welcomePagePrivacyPolicyIntro: "https://www.mozilla.org/en-US/privacy/",
     welcomePageNoExternalBrowserErrorChromium:
       "https://www.mozilla.org/firefox/new/",
     welcomePageTryOtherExtensionChromium: "https://mzl.la/dbe-firefox",

--- a/src/shared/pages/welcomePage/style.css
+++ b/src/shared/pages/welcomePage/style.css
@@ -101,6 +101,12 @@ span {
   margin-top: 5px;
 }
 
+p[data-locale="welcomePagePrivacyPolicyIntro"],
+p[data-locale="welcomePagePrivacyPolicyDescription"],
+p[data-locale="welcomePagePrivacyPolicyInteractionData"] {
+  font-size: 14px;
+}
+
 /* Shortcuts List Styling */
 #shortcuts-list {
   margin-top: -20px;


### PR DESCRIPTION
Added privacy policy and moved telemetry toggle to the bottom of the welcome page.

There were some issues with adding new lines to the welcome page within the same `data-locale` tag which seem to be preexisting. For now I've made the Privacy Policy three separate pararaphs.

![image](https://github.com/mozilla-extensions/firefox-bridge/assets/30131536/b0d4b002-cd40-4147-8d0c-31ab99674c50)
