### PR TITLE
Update glean.js and force python 3.11 to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ A Chromium and Firefox extension that allows the user to open Firefox from Chrom
 ## Requirements
 
 - Firefox Nightly or Developer Edition 122+
-- Some Chromium browser 88+ 
+- Some Chromium browser 88+
 
 ## Development
 
 Run `npm i` to install dependencies.
 
 Run `npm run build` to build the extension.
+
+> [!WARNING]
+> `npm run build` requires python < 3.12. You may want to specify a different python version if your default python version is 3.12 or above: `GLEAN_PYTHON=python3.11 npm run build`
 
 To see changes made to the extension, first build the extension, then reload the extension in the browser.
 
@@ -48,9 +51,9 @@ The tests use the files in the `build` folder. Since the shared logic is the sam
 
 ### Building
 
-Since the Firefox and Chromium extension has a lot of shared logic, but also independent logic, the build process is a bit complicated. 
+Since the Firefox and Chromium extension has a lot of shared logic, but also independent logic, the build process is a bit complicated.
 
-- The `src` folder contains the `shared`, `_locales`, `firefox`, and `chromium` folders. 
+- The `src` folder contains the `shared`, `_locales`, `firefox`, and `chromium` folders.
 - The `chromium` and `firefox` folders contain an `interfaces` folder that contains the interfaces for the shared logic.
 - The import statements within the `shared` folder will always point to the code in the `chromium/interfaces` folder. This is to simplify development within the IDE.
 - The `build` directory holds the built extension and the `dist` folder holds the zipped version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "firefox-launch",
+  "name": "firefox-bridge",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "firefox-launch",
+      "name": "firefox-bridge",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MPL-2.0",
       "dependencies": {
-        "@mozilla/glean": "^2.0.0",
+        "@mozilla/glean": "^2.0.5",
         "ua-parser-js": "^1.0.37"
       },
       "devDependencies": {
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.0.tgz",
-      "integrity": "sha512-4cVhtcWGkLb+KA+SGae0e68PGGNGFr/6nEi2M49J5EgFpEfNrzEAffJCi9PuKetjNeMdkFD6ZetSBvOJbrslEA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
+      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@mozilla/glean": "^2.0.0",
+    "@mozilla/glean": "^2.0.5",
     "ua-parser-js": "^1.0.37"
   }
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1894635 for why Python 3.12 does not work well with Glean. It was fixed but we're stuck on Glean.js v2.0.5 since newer versions don't work with webextensions anymore apparently 🤷 